### PR TITLE
5077: remove MINIO_ROOT_USER and rename to remove unecessary "public"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,7 +94,7 @@ services:
       AUDIO_TTS_OPENAI_API_BASE_URL: "https://tts.itkdev.dk/"
       AUDIO_TTS_OPENAI_API_KEY: ${TTS_API_KEY}
       # WAS
-      WAS_REDIRECT: ${WAS_REDIRECT:-"https://was.digst.dk/ai-aarhuskommune-dk"}
+      WAS_REDIRECT_URL: ${WAS_REDIRECT_URL:-"https://was.digst.dk/ai-aarhuskommune-dk"}
     networks:
       - app
       - frontend


### PR DESCRIPTION
https://leantime.itkdev.dk/TimeTable/TimeTable?showTicketModal=5077#/tickets/showTicket/5077

- Rename PUBLIC_WAS_REDIRECT to WAS_REDIRECT (for building in svelte, PUBLIC is necessary, but this is not relevant (anymore))
- Change MINIO_ROOT_USER to WAS_REDIRECT

Friends with: https://github.com/itk-dev/open-webui/pull/22
